### PR TITLE
test: stabilize `feature_fee_estimation.py` using controlled fee tiers

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -169,11 +169,30 @@ class EstimateFeeTest(BitcoinTestFramework):
         # We shuffle our confirmed txout set before each set of transactions
         # small_txpuzzle_randfee will use the transactions that have inputs already in the chain when possible
         # resorting to tx's that depend on the mempool when those run out
+        
+        # Define a controlled fee tier system
+        # Each tuple: (fee_multiplier relative to min_fee, probability of this tier)
+        fee_tiers = [(1, 0.2), (5, 0.3), (10, 0.3), (20, 0.2)]
+
+        # Precompute cumulative probabilities for random selection
+        cum_probs = []
+        total = 0
+        for _, prob in fee_tiers:
+            total += prob
+            cum_probs.append(total)
+
         for _ in range(numblocks):
             random.shuffle(self.confutxo)
             batch_sendtx_reqs = []
             for _ in range(random.randrange(100 - 50, 100 + 50)):
                 from_index = random.randint(1, 2)
+                # Select fee tier using weighted probabilities
+                r = random.random()
+                for idx, threshold in enumerate(cum_probs):
+                    if r <= threshold:
+                        fee_multiplier = fee_tiers[idx][0]
+                        break
+
                 (tx_bytes, fee) = small_txpuzzle_randfee(
                     self.wallet,
                     self.nodes[from_index],
@@ -181,7 +200,7 @@ class EstimateFeeTest(BitcoinTestFramework):
                     self.memutxo,
                     Decimal("0.005"),
                     min_fee,
-                    min_fee,
+                    min_fee * fee_multiplier,
                     batch_sendtx_reqs,
                 )
                 tx_kbytes = tx_bytes / 1000.0
@@ -292,7 +311,6 @@ class EstimateFeeTest(BitcoinTestFramework):
             dec_txs = [res["result"] for res in node.batch([node.decoderawtransaction.get_request(tx["hex"]) for tx in txs])]
             self.wallet.scan_txs(dec_txs)
 
-
         # Mine the last replacement txs
         self.sync_mempools(wait=0.1, nodes=[node, miner])
         self.generate(miner, 1)
@@ -321,7 +339,6 @@ class EstimateFeeTest(BitcoinTestFramework):
         # Start node and ensure the fee_estimates.dat file was not read
         self.start_node(0)
         assert_equal(self.nodes[0].estimatesmartfee(1)["errors"], ["Insufficient data or no feerate found"])
-
 
     def test_estimate_dat_is_flushed_periodically(self):
         fee_dat = self.nodes[0].chain_path / "fee_estimates.dat"
@@ -374,7 +391,6 @@ class EstimateFeeTest(BitcoinTestFramework):
         fee_dat_current_content = open(fee_dat, "rb").read()
         assert_not_equal(fee_dat_current_content, fee_dat_initial_content)
 
-
     def test_acceptstalefeeestimates_option(self):
         # Get the initial fee rate while node is running
         fee_rate = self.nodes[0].estimatesmartfee(1)["feerate"]
@@ -425,7 +441,6 @@ class EstimateFeeTest(BitcoinTestFramework):
         # conservative mode will consider longer time horizons while economical mode does not
         # Check the fee estimates for both modes after mining low fee transactions.
         check_fee_estimates_btw_modes(self.nodes[0], high_feerate, low_feerate)
-
 
     def run_test(self):
         self.log.info("This test is time consuming, please be patient")


### PR DESCRIPTION
When `estimaterawfee` is called with the long horizon and a confirmation target of 1 block, the estimator attempts to determine what fee rate has historically resulted in transactions being confirmed within one block with sufficiently high probability.
The long horizon does not examine only the past 24 individual blocks. Instead, it uses a long-term historical record of transactions and applies a slow decay factor so that older data still contributes to the calculation. In this context, 24 refers to the scale, meaning that confirmation statistics are grouped into periods of 24 blocks rather than tracked block-by-block. The scale defines how many real blocks are compressed into one tracking unit (period). For example, with a scale of 24, confirmations are recorded in 24-block intervals.

Transactions are grouped into fee rate buckets, ordered from highest to lowest fee rates. The estimator scans these buckets starting from the highest fee range downward. For each bucket, it checks how many transactions were confirmed within the required target (in this case, within one block), how many were confirmed later, and how many failed. 

If a single bucket does not contain enough transactions to meet the minimum statistical requirement, the estimator combines it with the next lower bucket. This accumulation continues until the total number of transactions in the combined bucket range reaches the required minimum sample size.

Only after enough transactions are collected does the estimator evaluate whether the confirmation success rate meets the required threshold. If no bucket range satisfies both the minimum sample requirement and the success probability condition, the long horizon returns “insufficient data” instead of a fee estimate.

To understand the cause of the failure I added some debug logs to `EstimateMedianVal()` where fee estimation logic happens in my branch [here](https://github.com/bitcoin/bitcoin/commit/65a1301238204f6e83e2744a42aee0652c3c7d7b).

After running the fee estimation functional test, the failure occurs at `check_raw_estimates(node, fees_seen)` on the first iterations (i.e trying to estimate fee rate for the next block and couldn't get the fee rate estimates for long horizon) for `node1`.

Result I got from the logs: 

```
2026-02-22T14:50:35.614766Z [httpworker.12] [policy/fees.cpp:347] [EstimateMedianVal] [estimatefee] Current bucket range from 189 to 118: total historical tx units in this range = 169.53, minimum required for stable estimate = 144.93
2026-02-22T14:50:35.614769Z [httpworker.12] [policy/fees.cpp:369] [EstimateMedianVal] [estimatefee] Checking fee bucket range 189 to 118 (higher fees first):
Transactions confirmed within target (1 blocks): 169.53
Total transactions ever confirmed in this range: 169.53
Transactions that left the mempool unconfirmed after target: 0.00
Transactions currently still waiting in mempool beyond target: 14
2026-02-22T14:50:35.614772Z [httpworker.12] [policy/fees.cpp:377] [EstimateMedianVal] [estimatefee] Calculated success rate for this fee range (curPct) = 0.9237 which 92.37%
in percentExplanation: Based on historical confirmations, transactions that left unconfirmed, and those still pending, a transaction paying this fee has roughly 92.37% chance of confirming within 1 block(s).
2026-02-22T14:50:35.614775Z [httpworker.12] [policy/fees.cpp:385] [EstimateMedianVal] [estimatefee] FAIL: The transaction fee range from bucket 189 to 118 did NOT meet the target confirmation rate.
Current success rate = 0.92 (92.37%), which is below the required 0.95 (95.00%).
2026-02-22T14:50:35.614778Z [httpworker.12] [policy/fees.cpp:398] [EstimateMedianVal] [estimatefee] Why it may have failed:
- Not enough historical transaction data in this fee range (small sample size, noisy data).
- Many transactions are still unconfirmed in the mempool (extraNum=14), lowering the effective success rate.
2026-02-22T14:50:35.614781Z [httpworker.12] [policy/fees.cpp:332] [EstimateMedianVal] [estimatefee] Checking bucket 117 (transactions with fees up to 301403.29 sats/vB): historical transactions ~0.00, confirmed within target ~0.00, dropped after target ~0.00, currently still unconfirmed for target=0, older unconfirmed transactions=0
From the logs, we can see the estimator successfully accumulated enough historical transaction data for statistical evaluation:
Current bucket range from 189 to 118:
total historical tx units = 169.53
minimum required = 144.93
This means the minimum sample size requirement (the partialNum < sufficientTxVal / (1 - decay) condition in EstimateMedianVal()) was satisfied. Therefore, I think the failure is not due to insufficient sample size.
The estimator then evaluates the success statistics for this combined bucket range:
Confirmed within target (1 block): 169.53
Total ever confirmed: 169.53
Currently still unconfirmed beyond target: 14
Dropped after target: 0

```

The calculated success rate (`curPct`) is:
`double curPct = nConf / (totalNum + failNum + extraNum);`
`curPct = 0.9237 same as 92.37%`

the failure occurs at the success comparison step inside `EstimateMedianVal()`:

```
if (curPct < successBreakPoint) {
// Failure condition
}
```

Since: 0.9237 < 0.95 the bucket range from `189 to 118` is rejected.

The reason the success rate is reduced is because of the 14 transactions that are still in the mempool beyond the target. These are counted as “extra” transactions (`extraNum`), and they lower the effective probability that a new transaction paying this fee would confirm within one block.

After this rejection, the estimator continues scanning lower fee buckets ( by “Checking bucket 117…”). However, bucket 117 below has effectively less historical transactions, so it cannot improve the success probability. As a result, no bucket range satisfies both:
- The minimum statistical sample size requirement
- The required confirmation probability threshold (95%)


Because no valid range is found, `EstimateMedianVal()` exits without setting `foundAnswer = true`, and ultimately returns failure (no feerate). That propagates back through `estimateRawFee()` and results in the long horizon returning “insufficient data” for `conf_target = 1`.

**Reason of this failure from the functional test**
The random nature of the `transact_and_mine` where each block contains a random number of transactions (between 50 and 150) with randomly selected fee rates can cause the long-horizon fee estimator to fail in producing reliable estimates. In some runs, fewer transactions end up paying higher fees, leaving many high-fee transactions unconfirmed in the mempool beyond the target block. In the `EstimateMedianVal()` function, these unconfirmed transactions are counted as `extraNum`, which reduces the effective success probability. If the resulting success rate falls below the required threshold (95%), the long-horizon estimator reports “insufficient data” instead of returning a fee estimate.

To reduce or mitigate this issue, here are some possible approaches I thought of :

- Reduce the number of transactions mined per block
Limiting the number of transactions per block to, for example, 50–100, can increase the proportion of higher-fee transactions that get confirmed within the target. However, this reduces the realism of the test, and finding a perfect “sweet spot” for all random runs is essentially difficult or impossible. It can only reduce the probability of failure, not eliminate it completely.

- Mine additional blocks to clear outstanding transactions
Many high-fee transactions remain in the mempool because they were not confirmed within the first 10 blocks. I ran an experiment [code](https://github.com/bitcoin/bitcoin/commit/8790e470f68aaffd43fb47189dcc2c62cc80e5f7) by running a loop to mine extra blocks until the mempool is cleared, so I can find an estimate of how many more blocks we can mine before we can clear the mempool from that we can know how many more blocks we can add to the initial 10 that could allow the estimator to gather sufficient historical confirmations for the long horizon. It turns out in several random runs, it takes between 14-20 extra blocks to be mined to clear the mempool. So I think adjusting the number of mined blocks from 10 to 15 will limit this failure, not sure if it will eliminate it though.

- Handle insufficient data gracefully in check_raw_estimates()
Either using approach 1 or 2 I think the check_raw_estimates() function should be updated to handle these cases without failing or raising errors and also documenting in the test when such issues can occur. 

I opted out using approach 2 [here](https://github.com/bitcoin/bitcoin/commit/86e33d80079480093182b8f339caab8b62a8c35c).